### PR TITLE
[MNG-6829] Replace StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/src/main/java/org/apache/maven/plugins/linkcheck/LinkcheckReport.java
+++ b/src/main/java/org/apache/maven/plugins/linkcheck/LinkcheckReport.java
@@ -35,7 +35,6 @@ import org.apache.maven.settings.Settings;
 import org.codehaus.plexus.i18n.I18N;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.ReaderFactory;
-import org.codehaus.plexus.util.StringUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -321,7 +320,7 @@ public class LinkcheckReport
 
     private void checkEncoding()
     {
-        if ( StringUtils.isEmpty( encoding ) )
+        if ( encoding == null || encoding.isEmpty() )
         {
             if ( getLog().isWarnEnabled() )
             {
@@ -401,7 +400,7 @@ public class LinkcheckReport
         linkCheck.setExcludedPages( getExcludedPages() );
         linkCheck.setExcludedHttpStatusErrors( asIntArray( excludedHttpStatusErrors ) );
         linkCheck.setExcludedHttpStatusWarnings( asIntArray( excludedHttpStatusWarnings ) );
-        linkCheck.setEncoding( ( StringUtils.isNotEmpty( encoding ) ? encoding : ReaderFactory.UTF_8 ) );
+        linkCheck.setEncoding( ( (encoding != null && !encoding.isEmpty()) ? encoding : ReaderFactory.UTF_8 ) );
 
         HttpBean bean = new HttpBean();
         bean.setMethod( httpMethod );

--- a/src/main/java/org/apache/maven/plugins/linkcheck/LinkcheckReportGenerator.java
+++ b/src/main/java/org/apache/maven/plugins/linkcheck/LinkcheckReportGenerator.java
@@ -241,7 +241,7 @@ public class LinkcheckReportGenerator
         sink.rawText( i18n.getString( "linkcheck-report", locale, "report.linkcheck.summary.table.httpMethod" ) );
         sink.tableCell_();
         sink.tableCell();
-        if ( StringUtils.isEmpty( httpMethod ) )
+        if ( httpMethod == null || httpMethod.isEmpty() )
         {
             sink.text( i18n.getString( "linkcheck-report", locale, "report.linkcheck.summary.table.none" ) );
         }

--- a/src/main/java/org/apache/maven/plugins/linkcheck/SiteInvoker.java
+++ b/src/main/java/org/apache/maven/plugins/linkcheck/SiteInvoker.java
@@ -50,7 +50,6 @@ import org.apache.maven.shared.invoker.PrintStreamHandler;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.ReaderFactory;
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.WriterFactory;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 
@@ -87,7 +86,7 @@ public class SiteInvoker
         throws IOException
     {
         String mavenHome = getMavenHome();
-        if ( StringUtils.isEmpty( mavenHome ) )
+        if ( mavenHome == null || mavenHome.isEmpty() )
         {
             // CHECKSTYLE_OFF: LineLength
             getLog().error( "Could NOT invoke Maven because no Maven Home is defined. "


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu